### PR TITLE
Update .claudelint.yaml with documentation link

### DIFF
--- a/.claudelint.yaml
+++ b/.claudelint.yaml
@@ -1,6 +1,6 @@
 # Example claudelint configuration
 # Copy this file to your repository root and customize as needed
-# TODO: add https://github.com/stbenjam/claudelint/tree/main
+# Documentation: https://github.com/stbenjam/claudelint
 rules:
   plugin-json-required:
     enabled: true


### PR DESCRIPTION
Replaced the TODO comment in `.claudelint.yaml` with a link to the claudelint repository documentation.

---
*PR created automatically by Jules for task [1693110268189815537](https://jules.google.com/task/1693110268189815537) started by @Ven0m0*