### PR TITLE
Fix pattern processing order and prevent double-prefixing in SafeDependencyUpdater

### DIFF
--- a/plugins/conserve/scripts/safe_replacer.py
+++ b/plugins/conserve/scripts/safe_replacer.py
@@ -21,22 +21,22 @@ class SafeDependencyUpdater:
     def __init__(self) -> None:
         """Initialize the safe dependency updater."""
         self.patterns = {
-            # Match only standalone references (not already prefixed)
-            "standalone_git_review": r"\bgit-workspace-review\b",
-            "standalone_review_core": r"\breview-core\b",
-            # Match wrong prefixes
+            # Match wrong prefixes first
             "wrong_workspace_prefix": r"workspace-utils:git-workspace-review",
             "wrong_workflow_prefix": r"workflow-utils:review-core",
             # Match full old plugin paths
             "old_skill_paths": r"~?/\.claude/skills/",
+            # Match only standalone references (not already prefixed)
+            "standalone_git_review": r"(?<!:)\bgit-workspace-review\b",
+            "standalone_review_core": r"(?<!:)\breview-core\b",
         }
 
         self.replacements = {
-            "standalone_git_review": "sanctum:git-workspace-review",
-            "standalone_review_core": "imbue:review-core",
             "wrong_workspace_prefix": "sanctum:git-workspace-review",
             "wrong_workflow_prefix": "imbue:review-core",
             "old_skill_paths": "",
+            "standalone_git_review": "sanctum:git-workspace-review",
+            "standalone_review_core": "imbue:review-core",
         }
 
     def update_file(self, file_path: Path) -> tuple[bool, int]:

--- a/plugins/conserve/tests/unit/scripts/test_safe_replacer.py
+++ b/plugins/conserve/tests/unit/scripts/test_safe_replacer.py
@@ -117,7 +117,7 @@ class TestSafeDependencyUpdaterImplementation:
         Given a skill file with wrong workspace-utils: prefix
         When updating the file
         Then patterns are applied in dictionary order
-        Note: This reveals that standalone pattern runs before wrong_prefix pattern
+        Note: Specific patterns now run before standalone patterns.
         """
         # Arrange
         temp_skill_file.write_text("Use workspace-utils:git-workspace-review\n")
@@ -128,9 +128,9 @@ class TestSafeDependencyUpdaterImplementation:
         # Assert
         assert updated is True
         content = temp_skill_file.read_text()
-        # Due to pattern processing order, standalone pattern matches first
-        # This creates "workspace-utils:sanctum:git-workspace-review"
-        # (This could be considered a bug - more specific patterns should run first)
+        # Due to correct pattern processing order, specific pattern matches first
+        # This creates "sanctum:git-workspace-review" and not double prefixed.
+        assert "workspace-utils:sanctum:git-workspace-review" not in content
         assert "sanctum:git-workspace-review" in content
 
     @pytest.mark.bdd


### PR DESCRIPTION
Fix pattern processing order and prevent double-prefixing in SafeDependencyUpdater

* Reordered \`self.patterns\` and \`self.replacements\` to match specific patterns
  (e.g., \`wrong_workspace_prefix\`) before standalone references.
* Added negative lookbehind assertions (\`(?<!:)\`) to standalone regex patterns
  to prevent double-prefixing.
* Updated corresponding test \`test_updater_processes_patterns_in_order\` to
  assert the correct and resolved substitution behavior.

---
*PR created automatically by Jules for task [18251932938309265364](https://jules.google.com/task/18251932938309265364) started by @Ven0m0*