### PR TITLE
🔒 Fix insecure HTTP download for jdt-language-server

### DIFF
--- a/claude/skills/lsp-enable/references/lsp-server-registry.md
+++ b/claude/skills/lsp-enable/references/lsp-server-registry.md
@@ -127,7 +127,7 @@ Machine-readable registry of LSP servers with verification and installation comm
 **Manual Installation:**
 ```bash
 # Download latest snapshot
-curl -LO http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+curl -LO https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
 
 # Extract to home directory
 mkdir -p ~/jdtls

--- a/claude/skills/lsp-enable/references/lsp-setup-verification.md
+++ b/claude/skills/lsp-enable/references/lsp-setup-verification.md
@@ -213,7 +213,7 @@ rustup component add rust-analyzer
 brew install jdtls
 
 # Manual
-curl -LO http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+curl -LO https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
 mkdir -p ~/jdtls && tar -xzf jdt-language-server-latest.tar.gz -C ~/jdtls
 ```
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was insecure HTTP protocol usage when downloading the Eclipse JDT Language Server snapshot.
⚠️ **Risk:** Downloading an executable tarball over unencrypted HTTP exposes the process to Man-in-the-Middle (MITM) attacks. An attacker could intercept the request and provide a modified, malicious version of the language server, which would then be extracted and run locally.
🛡️ **Solution:** Changed the protocol from `http://` to `https://` for the `download.eclipse.org` URL in both `lsp-setup-verification.md` and `lsp-server-registry.md`. Since `download.eclipse.org` supports HTTPS, this simple change ensures the download is encrypted and secure.

---
*PR created automatically by Jules for task [1507436581840873312](https://jules.google.com/task/1507436581840873312) started by @Ven0m0*