### PR TITLE
⚡ perf(codebase_audit): eliminate redundant dependency analysis

### DIFF
--- a/claude/skills/code-execution/examples/codebase_audit.py
+++ b/claude/skills/code-execution/examples/codebase_audit.py
@@ -18,12 +18,15 @@ issues = {
     'no_docstrings': []
 }
 
+total_lines = 0
+
 # Analyze each file (metadata only, not source!)
 for file in files:
     file_str = str(file)
 
     # Get complexity metrics
     deps = analyze_dependencies(file_str)
+    total_lines += deps.get('lines', 0)
 
     # Flag high complexity
     if deps.get('complexity', 0) > 15:
@@ -54,7 +57,7 @@ for file in files:
 # Return summary (NOT all the data!)
 result = {
     'files_audited': len(files),
-    'total_lines': sum(d.get('lines', 0) for d in [analyze_dependencies(str(f)) for f in files]),
+    'total_lines': total_lines,
     'issues': {
         'high_complexity': len(issues['high_complexity']),
         'unused_imports': len(issues['unused_imports']),
@@ -67,7 +70,7 @@ result = {
     )[:5]  # Only top 5
 }
 
-print(f"\\nAudit complete:")
+print("\\nAudit complete:")
 print(f"  High complexity files: {result['issues']['high_complexity']}")
 print(f"  Files with unused imports: {result['issues']['unused_imports']}")
 print(f"  Large files (>500 lines): {result['issues']['large_files']}")


### PR DESCRIPTION
💡 **What:** Eliminated a redundant O(N) pass mapping the `analyze_dependencies` function. Instead, `total_lines` is tracked on the fly during the primary loop parsing the files.

🎯 **Why:** `analyze_dependencies` is likely an expensive operation, potentially doing heavy I/O and parsing logic. `codebase_audit.py` was calling this operation again inside a secondary list-comprehension iteration `sum(d.get('lines', 0) for d in [analyze_dependencies(str(f)) for f in files])`, halving the potential performance of the script.

📊 **Measured Improvement:**
Measured using a mock `analyze_dependencies` with a 0.01s sleep per call.

- **Baseline:** ~11.26s for 541 files
- **Improved:** ~5.60s for 541 files

Almost an exact 2x performance increase.

---
*PR created automatically by Jules for task [2781355892291101235](https://jules.google.com/task/2781355892291101235) started by @Ven0m0*