### PR TITLE
🧹 Extract CLI output logic to output_strategies function

### DIFF
--- a/plugins/conserve/scripts/growth-controller.py
+++ b/plugins/conserve/scripts/growth-controller.py
@@ -344,6 +344,60 @@ class GrowthController:
         return base_requirements
 
 
+
+def output_strategies(strategies: dict[str, Any], args: argparse.Namespace) -> None:
+    """Output control strategies in the requested format."""
+    if args.output_json:
+        print(json.dumps(strategies, indent=2))
+    else:
+        strategy_type = strategies['metadata']['strategy_type'].upper()
+        print(f"Growth Control Strategy: {strategy_type}")
+        print("=" * 60)
+        print(f"Analysis Severity: {strategies['metadata']['analysis_severity']}")
+        target_rate = strategies['metadata']['target_growth_rate']
+        print(f"Target Growth Rate: {target_rate:.1%}")
+        print()
+
+        print("Automated Controls:")
+        print("-" * 20)
+        for control in strategies["automated_controls"]:
+            print(f"- {control['name']} ({control['priority']})")
+            print(f"  {control['description']}")
+
+        print("\nManual Controls:")
+        print("-" * 20)
+        for control in strategies["manual_controls"]:
+            print(f"- {control['name']} ({control['priority']})")
+            print(f"  {control['description']}")
+
+        print("\nPreventive Strategies:")
+        print("-" * 20)
+        for strategy in strategies["preventive_strategies"]:
+            print(f"- {strategy['name']} ({strategy['priority']})")
+            print(f"  {strategy['description']}")
+
+        if args.verbose:
+            print("\nImplementation Plan:")
+            print("-" * 20)
+            for phase, details in strategies["implementation_plan"].items():
+                if isinstance(details, dict):
+                    title = phase.replace('_', ' ').title()
+                    duration = details.get('duration', 'Unknown duration')
+                    print(f"\n{title} ({duration}):")
+                    actions = details.get('actions', [])
+                    if isinstance(actions, list):
+                        for action in actions:
+                            print(f"  - {action}")
+
+            print("\nMonitoring Requirements:")
+            print("-" * 20)
+            reqs = strategies["monitoring_requirements"]
+            if isinstance(reqs, dict):
+                print(f"Frequency: {reqs.get('frequency', 'Unknown')}")
+                print(f"Metrics: {', '.join(reqs.get('metrics', []))}")
+                print(f"Alerts: {', '.join(reqs.get('alerts', []))}")
+
+
 def main() -> None:
     """Generate context growth control strategies."""
     parser = argparse.ArgumentParser(
@@ -385,51 +439,7 @@ def main() -> None:
         args.strategy_type,
     )
 
-    if args.output_json:
-        print(json.dumps(strategies, indent=2))
-    else:
-        print(f"Growth Control Strategy: {strategies['metadata']['strategy_type'].upper()}")
-        print("=" * 60)
-        print(f"Analysis Severity: {strategies['metadata']['analysis_severity']}")
-        print(f"Target Growth Rate: {strategies['metadata']['target_growth_rate']:.1%}")
-        print()
-
-        print("Automated Controls:")
-        print("-" * 20)
-        for control in strategies["automated_controls"]:
-            print(f"- {control['name']} ({control['priority']})")
-            print(f"  {control['description']}")
-
-        print("\nManual Controls:")
-        print("-" * 20)
-        for control in strategies["manual_controls"]:
-            print(f"- {control['name']} ({control['priority']})")
-            print(f"  {control['description']}")
-
-        print("\nPreventive Strategies:")
-        print("-" * 20)
-        for strategy in strategies["preventive_strategies"]:
-            print(f"- {strategy['name']} ({strategy['priority']})")
-            print(f"  {strategy['description']}")
-
-        if args.verbose:
-            print("\nImplementation Plan:")
-            print("-" * 20)
-            for phase, details in strategies["implementation_plan"].items():
-                if isinstance(details, dict):
-                    print(f"\n{phase.replace('_', ' ').title()} ({details.get('duration', 'Unknown duration')}):")
-                    actions = details.get('actions', [])
-                    if isinstance(actions, list):
-                        for action in actions:
-                            print(f"  - {action}")
-
-            print("\nMonitoring Requirements:")
-            print("-" * 20)
-            reqs = strategies["monitoring_requirements"]
-            if isinstance(reqs, dict):
-                print(f"Frequency: {reqs.get('frequency', 'Unknown')}")
-                print(f"Metrics: {', '.join(reqs.get('metrics', []))}")
-                print(f"Alerts: {', '.join(reqs.get('alerts', []))}")
+    output_strategies(strategies, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Extracted the CLI output logic inside `main` into a dedicated `output_strategies` function. Also, fixed line length errors.
💡 **Why:** `main()` was previously doing too much, resulting in `PLR0912 Too many branches` and `PLR0915 Too many statements` lint errors. Extracting the output concern makes the code more maintainable and readable.
✅ **Verification:** Ran `pipx run ruff check plugins/conserve/scripts/growth-controller.py` and verified no linting issues remain. Ran the unit tests using `PYTHONPATH=. pytest -o "addopts=" plugins/conserve/tests/unit/scripts/test_growth_controller.py` to verify that existing functionality works as intended.
✨ **Result:** The codebase is cleaner and follows standard complexity guidelines without any change in the external behavior.

---
*PR created automatically by Jules for task [12828484116655730298](https://jules.google.com/task/12828484116655730298) started by @Ven0m0*