### PR TITLE
🧹 [code health improvement] Prevent TodoWrite header from triggering TODO scanners

### DIFF
--- a/plugins/conserve/scripts/detect_duplicates.py
+++ b/plugins/conserve/scripts/detect_duplicates.py
@@ -124,7 +124,7 @@ def extract_blocks(
         try:
             content = filepath.read_text(encoding="utf-8", errors="ignore")
             lines = content.splitlines()
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             return []
 
     if len(lines) < min_lines:
@@ -234,7 +234,7 @@ def find_duplicates(
             content = filepath.read_text(encoding="utf-8", errors="ignore")
             lines = content.splitlines()
             total_lines += len(lines)
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
 
         # Extract blocks
@@ -322,7 +322,7 @@ def find_similar_functions(files: list[Path]) -> list[tuple[str, list[str]]]:
         try:
             content = filepath.read_text(encoding="utf-8", errors="ignore")
             func_names.extend(func_pattern.findall(content))
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
 
     # Group by common prefixes/suffixes

--- a/plugins/conserve/tests/conftest.py
+++ b/plugins/conserve/tests/conftest.py
@@ -66,7 +66,7 @@ tags:
 
 Test skill for validating token conservation workflow patterns.
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `token-conservation-test:quota-check`
 - `token-conservation-test:context-plan`
@@ -109,7 +109,7 @@ tags:
 
 Test skill for validating context optimization and MECW principles.
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `context-optimization-test:mecw-assessment`
 - `context-optimization-test:context-classification`

--- a/plugins/conserve/tests/unit/scripts/test_cli_smoke.py
+++ b/plugins/conserve/tests/unit/scripts/test_cli_smoke.py
@@ -154,7 +154,7 @@ class TestCLISmokeTests:
         with patch("sys.argv", ["quick_skill_optimizer.py", str(skill_file)]):
             try:
                 quick_skill_optimizer.main()
-            except SystemExit, AttributeError:
+            except (SystemExit, AttributeError):
                 pass
 
     @pytest.mark.bdd
@@ -170,7 +170,7 @@ class TestCLISmokeTests:
         with patch("sys.argv", ["aggressive_skill_optimizer.py", str(skill_file)]):
             try:
                 aggressive_skill_optimizer.main()
-            except SystemExit, AttributeError:
+            except (SystemExit, AttributeError):
                 pass
 
 

--- a/plugins/conserve/tests/unit/scripts/test_conservation_validator.py
+++ b/plugins/conserve/tests/unit/scripts/test_conservation_validator.py
@@ -201,7 +201,7 @@ class TestConservationValidator:
         assert "token_budget:" in frontmatter
         assert "progressive_loading:" in frontmatter
         assert "category: conservation" in frontmatter
-        assert "TodoWrite Items" in skill_content  # Conservation skills need tracking
+        assert "Required TodoWrite Items" in skill_content  # Conservation skills need tracking
 
     @pytest.mark.bdd
     @pytest.mark.unit

--- a/plugins/conserve/tests/unit/skills/test_context_optimization.py
+++ b/plugins/conserve/tests/unit/skills/test_context_optimization.py
@@ -62,7 +62,7 @@ tags:
 
 # Context Optimization Hub
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `context-optimization:mecw-assessment`
 - `context-optimization:context-classification`

--- a/plugins/conserve/tests/unit/skills/test_mcp_code_execution.py
+++ b/plugins/conserve/tests/unit/skills/test_mcp_code_execution.py
@@ -60,7 +60,7 @@ tags:
 
 # MCP Code Execution Hub
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `mcp-code-execution:task-analysis`
 - `mcp-code-execution:delegation-assessment`

--- a/plugins/conserve/tests/unit/skills/test_optimizing_large_skills.py
+++ b/plugins/conserve/tests/unit/skills/test_optimizing_large_skills.py
@@ -66,7 +66,7 @@ tags:
 
 # Large Skill Optimization Hub
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `optimizing-large-skills:skill-analysis`
 - `optimizing-large-skills:modularization-assessment`

--- a/plugins/conserve/tests/unit/skills/test_performance_monitoring.py
+++ b/plugins/conserve/tests/unit/skills/test_performance_monitoring.py
@@ -74,7 +74,7 @@ tags:
 
 # Performance Monitoring Hub
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `performance-monitoring:metrics-collection`
 - `performance-monitoring:threshold-analysis`
@@ -481,7 +481,7 @@ tags:
                 int(mock_claude_tools["Bash"]("nvidia-smi --list-gpus | wc -l")),
             )
             performance_status["gpu_available"] = gpu_available
-        except ValueError, Exception:
+        except (ValueError, Exception):
             performance_status["gpu_available"] = False
             error_count += 1
 

--- a/plugins/conserve/tests/unit/skills/test_token_conservation.py
+++ b/plugins/conserve/tests/unit/skills/test_token_conservation.py
@@ -73,7 +73,7 @@ tags:
 
 # Token Conservation Workflow
 
-## TodoWrite Items
+## Required TodoWrite Items
 
 - `token-conservation:quota-check`
 - `token-conservation:context-plan`


### PR DESCRIPTION
🎯 **What:** Changed markdown headers from `## TodoWrite Items` to `## Required TodoWrite Items` across test files. Also fixed pre-existing Python 3 syntax errors in exception handling to get tests running cleanly.
💡 **Why:** The string "TodoWrite" starting a line (after markdown hash symbols) triggers "TODO" scanning tools/linters to falsely flag it as an actionable TODO comment, creating noise in code health reports.
✅ **Verification:** Ran `pytest` suite and `ruff` linting over the test directories. Tests related to validating the presence of "TodoWrite Items" were updated and verify the new string.
✨ **Result:** Cleaned up code health flags without changing behavior, and improved test suite stability.

---
*PR created automatically by Jules for task [3504200331609033014](https://jules.google.com/task/3504200331609033014) started by @Ven0m0*