### PR TITLE
🧹 [Replace TODOs with config file copies in setup.sh]

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -64,7 +64,7 @@ echo "  ✅ MCP servers configured"
 
 # Create/update settings.json
 echo "⚙️  Creating settings.json..."
-# TODO: use config file from this repo
+cp "claude/settings.json" "$SETTINGS_FILE"
 
 echo "  ✅ settings.json created"
 
@@ -77,7 +77,7 @@ if [ -f "$CLAUDE_JSON" ]; then
 fi
 
 # Create/update .claude.json with MCP servers
-# TODO: use config file from this repo
+cp "claude/.mcp.json" "$CLAUDE_JSON"
 echo "✅ MCP servers configured in .claude.json"
 
 # Plugin installation instructions


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the presence of unresolved `TODO` comments in `setup.sh` lines 67 and 80, which instruct to copy configuration files from the repository but do not actually implement the logic. This leaves `settings.json` and `.claude.json` improperly initialized during setup.
💡 **Why:** Implementing these copies ensures that the setup script automatically initializes user settings from the defaults provided in the repository. This improves the maintainability of `setup.sh`, resolves incomplete state configurations, and replaces unimplemented `TODO` instructions with working code, making the file self-contained and clear.
✅ **Verification:** I confirmed the logic by verifying the files being copied (`claude/settings.json` and `claude/.mcp.json`) exist in the repository. Additionally, I ran the bash script through `bash -n setup.sh` and successfully ran the BATS test suite to ensure the shell scripts in the repository maintain correct execution syntax.
✨ **Result:** The `TODO` blocks are removed, and `setup.sh` now successfully copies `settings.json` and `.mcp.json` automatically, fixing the config creation and providing complete setup behavior.

---
*PR created automatically by Jules for task [8690698922432326595](https://jules.google.com/task/8690698922432326595) started by @Ven0m0*