### PR TITLE
🧹 [code health improvement] Remove commented-out imports in context_optimization_service.py

### DIFF
--- a/plugins/conserve/examples/context_optimization_service.py
+++ b/plugins/conserve/examples/context_optimization_service.py
@@ -19,12 +19,6 @@ TOKEN_BUFFER_MULTIPLIER = 0.9
 HIGH_SCORE_THRESHOLD = 0.8
 LOW_TOKEN_MULTIPLIER = 0.8
 
-# Note: These imports are for example usage only
-# from conservation.context_optimization_service import (
-#     ConservationContextOptimizer,
-#     ContentBlock,
-# )
-# from conservation.context_optimization_service import ConservationServiceRegistry
 
 
 @dataclass
@@ -422,12 +416,6 @@ registry.register_service(
 # Example usage patterns for other plugins
 def example_abstract_usage():
     """Demonstrate how Abstract plugin would use Conservation."""
-    # Abstract plugin code would do:
-    # from conservation.context_optimization_service import (
-    #     ConservationContextOptimizer,
-    #     ContentBlock,
-    # )
-
     # Create content blocks from skill analysis
     blocks = [
         ContentBlock(
@@ -461,9 +449,6 @@ def example_abstract_usage():
 
 def example_sanctum_usage():
     """Demonstrate how Sanctum plugin would use Conservation."""
-    # Sanctum plugin code would do:
-    # from conservation.context_optimization_service import ConservationServiceRegistry
-
     # Get the optimization service
     registry = ConservationServiceRegistry()
     optimize = registry.get_service("optimize_content")


### PR DESCRIPTION
🎯 **What:** Removed dead commented-out import statements from `plugins/conserve/examples/context_optimization_service.py` (specifically lines 22-27, 419-423, and 453-454).
💡 **Why:** Commented-out code causes clutter and should be removed to keep the codebase clean, readable, and maintainable. This aligns with the repository code health standards prioritizing the preservation of actual functionality while keeping files clean.
✅ **Verification:** Ran `ruff check` (formatting confirmed correct) and the Python test suite for `plugins/conserve` using `PYTHONPATH=/app pytest -o "addopts=" plugins/conserve/tests/` to verify no new regressions were introduced (three known pre-existing test failures passed unchanged). Also requested AI code review to ensure task adherence.
✨ **Result:** A cleaner and more maintainable `context_optimization_service.py` file with unneeded comments stripped away.

---
*PR created automatically by Jules for task [5084452230352608377](https://jules.google.com/task/5084452230352608377) started by @Ven0m0*