### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/agentlint.yml
+++ b/.github/workflows/agentlint.yml
@@ -1,4 +1,6 @@
 name: Lint LLM config files
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/claude-config/security/code-scanning/9](https://github.com/Ven0m0/claude-config/security/code-scanning/9)

To fix the problem, add an explicit `permissions` block that limits the `GITHUB_TOKEN` to the minimal scope required. This workflow only needs to read repository contents (for `actions/checkout`), and does not appear to need any write operations or special scopes like `pull-requests` or `issues`.

The best, least intrusive fix is to add a root-level `permissions` block (siblings with `on:` and `jobs:`) setting `contents: read`. That will apply to all jobs in the workflow, including `lint`, without altering its behavior. No additional methods, imports, or steps are required; we just add the YAML block near the top of `.github/workflows/agentlint.yml`, e.g. after the `name:` line so it is clearly visible.

Concretely, in `.github/workflows/agentlint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name:` and `on:` lines (or equivalently between `on:` and `jobs:`—either is valid, but we’ll choose right after `name:` for clarity). This explicitly documents and enforces minimal token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
