### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/claude-config/security/code-scanning/6](https://github.com/Ven0m0/claude-config/security/code-scanning/6)

In general, to fix this class of problem you add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or within the specific job that needs restricted permissions. The block should grant the minimal scopes required, typically `contents: read` for simple linting or validation workflows that only read the repository.

For this specific workflow, the `ruff` job only checks out code and runs a validation action; it does not need to write to the repository or interact with issues, PRs, etc. The single best fix is to add a `permissions` block to the `ruff` job that restricts `GITHUB_TOKEN` to read-only access to repository contents. This avoids changing behavior while documenting and enforcing least privilege. Concretely, in `.github/workflows/lint.yml`, under `jobs: ruff:`, insert:

```yaml
    permissions:
      contents: read
```

with proper indentation so it is a sibling to `runs-on`. No imports or other definitions are required, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
