### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,8 @@
 name: Ruff Code Formatter
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/claude-config/security/code-scanning/5](https://github.com/Ven0m0/claude-config/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job so that the `GITHUB_TOKEN` is limited to the minimal scopes needed. For a read‑only CI check that just checks out the code and runs a formatter, the minimal required permission is `contents: read`.

The best targeted fix is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) setting `contents: read`. This will apply to all jobs in this workflow (currently just `ruff`) and ensures the token cannot write to the repository. No other scopes (like `pull-requests: write`) are required because the job does not modify PRs, comment, or push changes.

Concretely, in `.github/workflows/ruff.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` line and the `on:` block (e.g., as new line 3, shifting subsequent lines down). No imports or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
