### PR TITLE
🧹 Remove unused pytest import in test_complex.py

### DIFF
--- a/claude/skills/toon-formatter/tests/test_complex.py
+++ b/claude/skills/toon-formatter/tests/test_complex.py
@@ -1,14 +1,16 @@
-import pytest
 import os
 import sys
 
 # Ensure module is in path
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 import importlib.util
 
-spec = importlib.util.spec_from_file_location("toon_convert", "claude/skills/toon-formatter/toon-convert.py")
+spec = importlib.util.spec_from_file_location(
+    "toon_convert", "claude/skills/toon-formatter/toon-convert.py"
+)
 toon_convert = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(toon_convert)
+
 
 def test_enc():
     data = {
@@ -23,7 +25,7 @@ def test_enc():
         "i": 123.45,
         "j": "123",
         "k": ["true", "false", "null", "other"],
-        "l": {"m": "true"}
+        "l": {"m": "true"},
     }
 
     expected = """a: "true"


### PR DESCRIPTION
🎯 **What:** Removed the unused `import pytest` from `claude/skills/toon-formatter/tests/test_complex.py` and formatted the file with `ruff`.
💡 **Why:** It removes dead code from the test file which improves maintainability and readability. Standardizing code formatting makes the code more aligned with Python guidelines.
✅ **Verification:** Ran `pytest` suite for the test and ensuring `ruff check` had no more warnings or errors. 
✨ **Result:** A cleaner test file aligned with codebase styling practices.

---
*PR created automatically by Jules for task [14647562615826347424](https://jules.google.com/task/14647562615826347424) started by @Ven0m0*