### PR TITLE
🔒 Fix Command Execution Risk via eval in install scripts

### DIFF
--- a/opencode-remote/install-local.sh
+++ b/opencode-remote/install-local.sh
@@ -155,7 +155,8 @@ install_systemd_services() {
 
   local current_user="${SUDO_USER:-$USER}"
   local current_home
-  current_home=$(eval echo "~$current_user")
+  current_home=$(getent passwd "$current_user" | cut -d: -f6)
+  [[ -n "$current_home" ]] || { echo "ERROR: Could not resolve home directory for user $current_user" >&2; exit 1; }
 
   # Resolve openchamber server script path
   local openchamber_bin openchamber_server node_bin

--- a/opencode-remote/install-local.sh
+++ b/opencode-remote/install-local.sh
@@ -155,7 +155,14 @@ install_systemd_services() {
 
   local current_user="${SUDO_USER:-$USER}"
   local current_home
-  current_home=$(getent passwd "$current_user" | cut -d: -f6)
+  if ! command -v getent &>/dev/null; then
+    echo "ERROR: getent is required to resolve the home directory for user $current_user" >&2
+    exit 1
+  fi
+  if ! current_home=$(getent passwd "$current_user" | cut -d: -f6); then
+    echo "ERROR: Could not resolve home directory for user $current_user" >&2
+    exit 1
+  fi
   [[ -n "$current_home" ]] || { echo "ERROR: Could not resolve home directory for user $current_user" >&2; exit 1; }
 
   # Resolve openchamber server script path

--- a/opencode-remote/install.sh
+++ b/opencode-remote/install.sh
@@ -123,7 +123,11 @@ install_systemd_services() {
   fi
 
   local current_user="${SUDO_USER:-$USER}"
-  local current_home; current_home=$(getent passwd "$current_user" | cut -d: -f6)
+  has getent || die "Required command not found: getent"
+  local current_home
+  if ! current_home=$(getent passwd "$current_user" | cut -d: -f6); then
+    die "Could not resolve home directory for user $current_user"
+  fi
   [[ -n "$current_home" ]] || die "Could not resolve home directory for user $current_user"
 
   # Resolve openchamber server script

--- a/opencode-remote/install.sh
+++ b/opencode-remote/install.sh
@@ -123,7 +123,8 @@ install_systemd_services() {
   fi
 
   local current_user="${SUDO_USER:-$USER}"
-  local current_home; current_home=$(eval echo "~$current_user")
+  local current_home; current_home=$(getent passwd "$current_user" | cut -d: -f6)
+  [[ -n "$current_home" ]] || die "Could not resolve home directory for user $current_user"
 
   # Resolve openchamber server script
   local openchamber_bin openchamber_server node_bin


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential command injection in `install.sh` and `install-local.sh`.
⚠️ **Risk:** Using `eval echo "~$user"` allows an attacker who can control the `SUDO_USER` or `USER` environment variables to execute arbitrary commands with the privileges of the script (often root).
🛡️ **Solution:** Switched to `getent passwd "$user" | cut -d: -f6`, which is a safe way to retrieve the home directory without shell interpretation. Added checks to ensure the home directory is successfully resolved.

---
*PR created automatically by Jules for task [1702576033164494073](https://jules.google.com/task/1702576033164494073) started by @Ven0m0*