### PR TITLE
🔒 [security] Prevent token exposure via command-line arguments

### DIFF
--- a/opencode-remote/docker-compose.opencode-container.yml
+++ b/opencode-remote/docker-compose.opencode-container.yml
@@ -40,7 +40,9 @@ services:
   cloudflared:
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
-    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+    environment:
+      TUNNEL_TOKEN: "${TUNNEL_TOKEN}"
+    command: tunnel --no-autoupdate run
     depends_on:
       opencode:
         condition: service_healthy

--- a/opencode-remote/docker-compose.yml
+++ b/opencode-remote/docker-compose.yml
@@ -21,7 +21,9 @@ services:
   cloudflared:
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
-    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+    environment:
+      TUNNEL_TOKEN: "${TUNNEL_TOKEN}"
+    command: tunnel --no-autoupdate run
     depends_on:
       openchamber:
         condition: service_healthy

--- a/opencode-remote/install-local.sh
+++ b/opencode-remote/install-local.sh
@@ -146,7 +146,7 @@ install_systemd_services() {
     echo "WARNING: $SYSTEMD_DIR not found. Skipping systemd service installation." >&2
     echo "  To start manually:"
     echo "    OPENCHAMBER_UI_PASSWORD=\"\$UI_PASSWORD\" node \$OPENCHAMBER_SERVER --port ${OPENCHAMBER_PORT:-3000} &"
-    echo "    cloudflared tunnel --no-autoupdate run --token \"\$TUNNEL_TOKEN\" &"
+    echo "    TUNNEL_TOKEN=\"\$TUNNEL_TOKEN\" cloudflared tunnel --no-autoupdate run &"
     echo ""
     echo "=== Installation complete ==="
     echo "Open: https://${TUNNEL_HOSTNAME}"

--- a/opencode-remote/install.sh
+++ b/opencode-remote/install.sh
@@ -117,7 +117,7 @@ install_systemd_services() {
     printf '\e[33mWARNING: systemd not found. Start manually:\e[0m\n' >&2
     printf '  OPENCHAMBER_UI_PASSWORD="%s" node <server> --port %s &\n' \
       "${UI_PASSWORD}" "${OPENCHAMBER_PORT:-3000}" >&2
-    printf '  cloudflared tunnel --no-autoupdate run --token "%s" &\n' \
+    printf '  TUNNEL_TOKEN="%s" cloudflared tunnel --no-autoupdate run &\n' \
       "${TUNNEL_TOKEN}" >&2
     return
   fi


### PR DESCRIPTION
This PR addresses a security vulnerability where sensitive tokens (TUNNEL_TOKEN) were passed as command-line arguments, making them visible in process listings.

🎯 **What:** The fix transitions the use of `TUNNEL_TOKEN` from the `--token` CLI flag to the `TUNNEL_TOKEN` environment variable in both the shell installation scripts and Docker Compose files.

⚠️ **Risk:** If left unfixed, the `TUNNEL_TOKEN` could be exposed to any user on the system who can run `ps` or inspect `/proc`, potentially allowing them to hijack the Cloudflare Tunnel.

🛡️ **Solution:**
- Updated `install.sh` and `install-local.sh` to show manual start instructions using `TUNNEL_TOKEN="token" cloudflared ...`.
- Updated `docker-compose.yml` and `docker-compose.opencode-container.yml` to use the `environment` section for `TUNNEL_TOKEN` and removed the `--token` flag from the `command`.
- Verified that `cloudflared` correctly picks up the token from the environment variable.
- Performed syntax and configuration validation on all modified files.

---
*PR created automatically by Jules for task [5881781206914153688](https://jules.google.com/task/5881781206914153688) started by @Ven0m0*