### PR TITLE
🔒 Fix unsafe tar extraction in session-init.sh

### DIFF
--- a/claude/hooks/session-init.sh
+++ b/claude/hooks/session-init.sh
@@ -15,11 +15,10 @@ ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
 TARBALL="gh_${VERSION#v}_linux_${ARCH}.tar.gz"
 
+TAR_DIR="gh_${VERSION#v}_linux_${ARCH}"
+
 echo "Installing gh ${VERSION}..."
-TEMP=$(mktemp -d)
-trap 'rm -rf "$TEMP"' EXIT
-curl -fsSL "https://github.com/cli/cli/releases/download/${VERSION}/${TARBALL}" | tar -xz -C "$TEMP"
-cp "$TEMP"/gh_*/bin/gh "$LOCAL_BIN/gh"
+curl -fsSL "https://github.com/cli/cli/releases/download/${VERSION}/${TARBALL}" | tar -xz -O "${TAR_DIR}/bin/gh" > "$LOCAL_BIN/gh"
 chmod 755 "$LOCAL_BIN/gh"
 
 [ -n "$CLAUDE_ENV_FILE" ] && echo "export PATH=\"$LOCAL_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"

--- a/claude/hooks/session-init.sh
+++ b/claude/hooks/session-init.sh
@@ -16,6 +16,7 @@ VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep
 TARBALL="gh_${VERSION#v}_linux_${ARCH}.tar.gz"
 
 TAR_DIR="gh_${VERSION#v}_linux_${ARCH}"
+trap ':' EXIT
 
 echo "Installing gh ${VERSION}..."
 curl -fsSL "https://github.com/cli/cli/releases/download/${VERSION}/${TARBALL}" | tar -xz -O "${TAR_DIR}/bin/gh" > "$LOCAL_BIN/gh"


### PR DESCRIPTION
🎯 **What:** Replaces insecure `tar -xz -C` extraction of an entire downloaded archive with targeted `tar -xz -O` extraction of a single executable file.
⚠️ **Risk:** If the downloaded archive were maliciously crafted (e.g. through compromised Github releases or MITM despite HTTPS), absolute paths or directory traversal paths (`../`) inside the archive could overwrite arbitrary files on the system under the permissions of the script runner.
🛡️ **Solution:** By instructing `tar` to extract only the specific binary directly to stdout (`-O`) and redirecting it to the destination file, we bypass the filesystem path construction entirely, neutralizing the path traversal vulnerability and eliminating the need for temporary directories.

---
*PR created automatically by Jules for task [3680252424247708034](https://jules.google.com/task/3680252424247708034) started by @Ven0m0*