### PR TITLE
🧹 Remove unused MAX_TURNS variable

### DIFF
--- a/opencode/skill/flow-next-opencode-ralph-init/templates/config.env
+++ b/opencode/skill/flow-next-opencode-ralph-init/templates/config.env
@@ -15,7 +15,6 @@ WORK_REVIEW={{WORK_REVIEW}}
 # Work settings
 BRANCH_MODE=new
 MAX_ITERATIONS=25
-# MAX_TURNS=  # optional; empty = no limit (unused for OpenCode, kept for parity)
 MAX_ATTEMPTS_PER_TASK=5
 # MAX_REVIEW_ITERATIONS=3  # fix+re-review cycles within one impl-review before giving up (default 3)
 # WORKER_TIMEOUT=3600  # seconds; default 1hr. Safety guard against runaway workers, not primary flow control

--- a/opencode/skill/flow-next-opencode-ralph-init/templates/ralph.sh
+++ b/opencode/skill/flow-next-opencode-ralph-init/templates/ralph.sh
@@ -326,7 +326,6 @@ source "$CONFIG"
 set +a
 
 MAX_ITERATIONS="${MAX_ITERATIONS:-25}"
-MAX_TURNS="${MAX_TURNS:-}"  # empty = no limit; unused for OpenCode (kept for parity)
 MAX_ATTEMPTS_PER_TASK="${MAX_ATTEMPTS_PER_TASK:-5}"
 WORKER_TIMEOUT="${WORKER_TIMEOUT:-3600}"  # 1hr default; safety guard against runaway workers
 BRANCH_MODE="${BRANCH_MODE:-new}"


### PR DESCRIPTION
🎯 **What:** Removed the unused `MAX_TURNS` variable from `ralph.sh` and `config.env` templates in the `flow-next-opencode-ralph-init` skill.
💡 **Why:** The variable was explicitly marked as unused ("unused for OpenCode"). Removing dead code improves the maintainability and readability of the scaffolded Ralph harness.
✅ **Verification:** 
- Used `grep` to ensure no references to `MAX_TURNS` remain in the template directory.
- Ran `bash -n` on `ralph.sh` to confirm no syntax errors were introduced.
- Verified changes via successful code review.
✨ **Result:** A cleaner and more focused set of templates for initializing the Ralph autonomous loop.

---
*PR created automatically by Jules for task [8453511849974995978](https://jules.google.com/task/8453511849974995978) started by @Ven0m0*