### PR TITLE
Add PM2 support to opencode-remote

### DIFF
--- a/opencode-remote/Makefile
+++ b/opencode-remote/Makefile
@@ -76,24 +76,45 @@ status:
 	@echo "Systemd services:"
 	@systemctl is-active openchamber 2>/dev/null && echo "  openchamber: active" || echo "  openchamber: inactive"
 	@systemctl is-active cloudflared-openchamber 2>/dev/null && echo "  cloudflared-openchamber: active" || echo "  cloudflared-openchamber: inactive"
+	@echo ""
+	@echo "PM2 services:"
+	@if command -v pm2 >/dev/null 2>&1; then pm2 list; else echo "  pm2 not installed"; fi
 
 restart:
 	@if docker compose ps -q 2>/dev/null | grep -q .; then \
 	  docker compose restart; \
+	elif command -v pm2 >/dev/null 2>&1 && pm2 list | grep -q "openchamber"; then \
+	  pm2 restart openchamber cloudflared-openchamber; \
 	else \
 	  systemctl restart openchamber cloudflared-openchamber 2>/dev/null || echo "No services running"; \
 	fi
 
-# ── Local / systemd targets ───────────────────────────────────────────────────
+# ── Local / systemd / PM2 targets ─────────────────────────────────────────────
 
 start:
-	systemctl start openchamber cloudflared-openchamber
+	@if command -v pm2 >/dev/null 2>&1 && pm2 list | grep -q "openchamber"; then \
+	  pm2 start openchamber cloudflared-openchamber; \
+	else \
+	  systemctl start openchamber cloudflared-openchamber; \
+	fi
 
 stop:
-	systemctl stop openchamber cloudflared-openchamber
+	@if command -v pm2 >/dev/null 2>&1 && pm2 list | grep -q "openchamber"; then \
+	  pm2 stop openchamber cloudflared-openchamber; \
+	else \
+	  systemctl stop openchamber cloudflared-openchamber; \
+	fi
 
 enable:
-	systemctl enable openchamber cloudflared-openchamber
+	@if command -v pm2 >/dev/null 2>&1 && pm2 list | grep -q "openchamber"; then \
+	  pm2 save; \
+	else \
+	  systemctl enable openchamber cloudflared-openchamber; \
+	fi
 
 disable:
-	systemctl disable openchamber cloudflared-openchamber
+	@if command -v pm2 >/dev/null 2>&1 && pm2 list | grep -q "openchamber"; then \
+	  echo "PM2 services are always enabled if started. Use 'pm2 delete' to remove."; \
+	else \
+	  systemctl disable openchamber cloudflared-openchamber; \
+	fi

--- a/opencode-remote/install-local.sh
+++ b/opencode-remote/install-local.sh
@@ -139,22 +139,8 @@ provision_tunnel() {
   TUNNEL_ID=$(jq -r '.TunnelID' "$SCRIPT_DIR/cloudflared/credentials.json")
 }
 
-install_systemd_services() {
-  echo "[4/4] Installing systemd services..."
-
-  if [[ ! -d "$SYSTEMD_DIR" ]]; then
-    echo "WARNING: $SYSTEMD_DIR not found. Skipping systemd service installation." >&2
-    echo "  To start manually:"
-    echo "    OPENCHAMBER_UI_PASSWORD=\"\$UI_PASSWORD\" node \$OPENCHAMBER_SERVER --port ${OPENCHAMBER_PORT:-3000} &"
-    echo "    TUNNEL_TOKEN=\"\$TUNNEL_TOKEN\" cloudflared tunnel --no-autoupdate run &"
-    echo ""
-    echo "=== Installation complete ==="
-    echo "Open: https://${TUNNEL_HOSTNAME}"
-    exit 0
-  fi
-
-  local current_user="${SUDO_USER:-$USER}"
-  local current_home
+prepare_local_env() {
+  current_user="${SUDO_USER:-$USER}"
   if ! command -v getent &>/dev/null; then
     echo "ERROR: getent is required to resolve the home directory for user $current_user" >&2
     exit 1
@@ -166,7 +152,7 @@ install_systemd_services() {
   [[ -n "$current_home" ]] || { echo "ERROR: Could not resolve home directory for user $current_user" >&2; exit 1; }
 
   # Resolve openchamber server script path
-  local openchamber_bin openchamber_server node_bin
+  local openchamber_bin
   openchamber_bin=$(readlink -f "$(command -v openchamber)")
   openchamber_server=$(dirname "$(dirname "$openchamber_bin")")/server/index.js
   node_bin=$(command -v node)
@@ -177,6 +163,11 @@ install_systemd_services() {
   fi
   echo "  Server script: $openchamber_server"
 
+  cloudflared_bin=$(command -v cloudflared)
+  port="${OPENCHAMBER_PORT:-3000}"
+}
+
+write_local_configs() {
   # Write secrets to restricted env file
   local env_target="/etc/openchamber/env"
   install -d -m 700 /etc/openchamber
@@ -187,9 +178,24 @@ TUNNEL_TOKEN=$TUNNEL_TOKEN
 EOF
   echo "  Wrote: $env_target (chmod 600)"
 
-  local cloudflared_bin
-  cloudflared_bin=$(command -v cloudflared)
-  local port="${OPENCHAMBER_PORT:-3000}"
+  # Copy credentials
+  local cloudflared_etc="/etc/cloudflared"
+  mkdir -p "$cloudflared_etc"
+  cp "$SCRIPT_DIR/cloudflared/credentials.json" "$cloudflared_etc/credentials.json"
+  chown "$current_user:$current_user" "$cloudflared_etc/credentials.json"
+  chmod 600 "$cloudflared_etc/credentials.json"
+}
+
+install_systemd_services() {
+  echo "[4/4] Installing systemd services..."
+
+  if [[ ! -d "$SYSTEMD_DIR" ]]; then
+    echo "WARNING: $SYSTEMD_DIR not found." >&2
+    return 1
+  fi
+
+  prepare_local_env
+  write_local_configs
 
   # openchamber service
   cat > "$SYSTEMD_DIR/openchamber.service" << EOF
@@ -242,13 +248,42 @@ EOF
   systemctl start openchamber.service cloudflared-openchamber.service
 }
 
+install_pm2_services() {
+  echo "[4/4] Installing PM2 services..."
+  install_global pm2
+
+  prepare_local_env
+  write_local_configs
+
+  # Start openchamber
+  OPENCHAMBER_UI_PASSWORD="${UI_PASSWORD}" pm2 start "$node_bin" \
+    --name openchamber \
+    -- "$openchamber_server" --port "$port"
+
+  # Start cloudflared
+  local cloudflared_etc="/etc/cloudflared"
+  TUNNEL_TOKEN="${TUNNEL_TOKEN}" pm2 start "$cloudflared_bin" \
+    --name cloudflared-openchamber \
+    -- tunnel --no-autoupdate run --credentials-file="$cloudflared_etc/credentials.json" --url="http://localhost:$port" "$TUNNEL_ID"
+
+  pm2 save
+  if command -v pm2-startup &>/dev/null; then
+    pm2 startup || true
+  fi
+}
+
 print_summary() {
   echo ""
   echo "=== Local installation complete ==="
   echo ""
   echo "Services enabled and started:"
-  echo "  systemctl status openchamber"
-  echo "  systemctl status cloudflared-openchamber"
+  if command -v pm2 &>/dev/null; then
+    echo "  pm2 list"
+    echo "  pm2 logs"
+  else
+    echo "  systemctl status openchamber"
+    echo "  systemctl status cloudflared-openchamber"
+  fi
   echo ""
   echo "Open: https://${TUNNEL_HOSTNAME}"
   echo "(UI Password is in .env as UI_PASSWORD)"
@@ -265,7 +300,13 @@ main() {
   install_openchamber
   install_cloudflared
   provision_tunnel
-  install_systemd_services
+
+  if [[ "${USE_PM2:-}" == "true" ]]; then
+    install_pm2_services
+  else
+    install_systemd_services || install_pm2_services
+  fi
+
   print_summary
 }
 

--- a/opencode-remote/install-local.sh
+++ b/opencode-remote/install-local.sh
@@ -267,7 +267,7 @@ install_pm2_services() {
     -- tunnel --no-autoupdate run --credentials-file="$cloudflared_etc/credentials.json" --url="http://localhost:$port" "$TUNNEL_ID"
 
   pm2 save
-  if command -v pm2-startup &>/dev/null; then
+  if command -v pm2 &>/dev/null; then
     pm2 startup || true
   fi
 }

--- a/opencode-remote/install.sh
+++ b/opencode-remote/install.sh
@@ -219,7 +219,7 @@ install_pm2_services() {
     -- tunnel --no-autoupdate run --credentials-file="$cloudflared_etc/credentials.json" --url="http://localhost:$port" "$tunnel_id"
 
   pm2 save
-  if has pm2-startup; then
+  if has pm2; then
     pm2 startup || true
   fi
 }

--- a/opencode-remote/install.sh
+++ b/opencode-remote/install.sh
@@ -110,33 +110,27 @@ install_cloudflared() {
   chmod +x /usr/local/bin/cloudflared
 }
 
-install_systemd_services() {
-  log "[4/4] Installing systemd services..."
-
-  if [[ ! -d "$SYSTEMD_DIR" ]]; then
-    printf '\e[33mWARNING: systemd not found. Start manually:\e[0m\n' >&2
-    printf '  OPENCHAMBER_UI_PASSWORD="%s" node <server> --port %s &\n' \
-      "${UI_PASSWORD}" "${OPENCHAMBER_PORT:-3000}" >&2
-    printf '  TUNNEL_TOKEN="$TUNNEL_TOKEN" cloudflared tunnel --no-autoupdate run &\n' >&2
-    printf '  If TUNNEL_TOKEN is not exported in your shell, export it or source your .env file first.\n' >&2
-    return
-  fi
-
-  local current_user="${SUDO_USER:-$USER}"
+prepare_local_env() {
+  current_user="${SUDO_USER:-$USER}"
   has getent || die "Required command not found: getent"
-  local current_home
   if ! current_home=$(getent passwd "$current_user" | cut -d: -f6); then
     die "Could not resolve home directory for user $current_user"
   fi
   [[ -n "$current_home" ]] || die "Could not resolve home directory for user $current_user"
 
-  # Resolve openchamber server script
-  local openchamber_bin openchamber_server node_bin
+  # Resolve paths
+  local openchamber_bin
   openchamber_bin=$(readlink -f "$(command -v openchamber)")
   openchamber_server=$(dirname "$(dirname "$openchamber_bin")")/server/index.js
   node_bin=$(command -v node)
   [[ -f "$openchamber_server" ]] || die "Cannot find openchamber server at $openchamber_server"
 
+  cloudflared_bin=$(command -v cloudflared)
+  port="${OPENCHAMBER_PORT:-3000}"
+  tunnel_id=$(jq -r '.TunnelID' "$SCRIPT_DIR/cloudflared/credentials.json")
+}
+
+write_local_configs() {
   # Secrets file (root-owned, chmod 600)
   local env_target="/etc/openchamber/env"
   install -d -m 700 /etc/openchamber
@@ -144,16 +138,24 @@ install_systemd_services() {
   printf 'OPENCHAMBER_UI_PASSWORD=%s\nTUNNEL_TOKEN=%s\n' \
     "${UI_PASSWORD}" "${TUNNEL_TOKEN}" > "$env_target"
 
-  local cloudflared_bin; cloudflared_bin=$(command -v cloudflared)
-  local port="${OPENCHAMBER_PORT:-3000}"
-  local tunnel_id; tunnel_id=$(jq -r '.TunnelID' "$SCRIPT_DIR/cloudflared/credentials.json")
-
   # Copy credentials
   local cloudflared_etc="/etc/cloudflared"
   mkdir -p "$cloudflared_etc"
   cp "$SCRIPT_DIR/cloudflared/credentials.json" "$cloudflared_etc/credentials.json"
   chown "${current_user}:${current_user}" "$cloudflared_etc/credentials.json"
   chmod 600 "$cloudflared_etc/credentials.json"
+}
+
+install_systemd_services() {
+  log "[4/4] Installing systemd services..."
+
+  if [[ ! -d "$SYSTEMD_DIR" ]]; then
+    printf '\e[33mWARNING: systemd not found.\e[0m\n' >&2
+    return 1
+  fi
+
+  prepare_local_env
+  write_local_configs
 
   # openchamber.service
   cat > "$SYSTEMD_DIR/openchamber.service" << EOF
@@ -198,8 +200,29 @@ EOF
   systemctl restart openchamber.service cloudflared-openchamber.service
 }
 
-# TODO: add pm2 support
-# install_global pm2
+install_pm2_services() {
+  log "[4/4] Installing PM2 services..."
+  install_global pm2
+
+  prepare_local_env
+  write_local_configs
+
+  # Start openchamber
+  OPENCHAMBER_UI_PASSWORD="${UI_PASSWORD}" pm2 start "$node_bin" \
+    --name openchamber \
+    -- "$openchamber_server" --port "$port"
+
+  # Start cloudflared
+  local cloudflared_etc="/etc/cloudflared"
+  TUNNEL_TOKEN="${TUNNEL_TOKEN}" pm2 start "$cloudflared_bin" \
+    --name cloudflared-openchamber \
+    -- tunnel --no-autoupdate run --credentials-file="$cloudflared_etc/credentials.json" --url="http://localhost:$port" "$tunnel_id"
+
+  pm2 save
+  if has pm2-startup; then
+    pm2 startup || true
+  fi
+}
 
 install_local() {
   [[ $EUID -eq 0 ]] || die "Local mode requires root: sudo bash install.sh"
@@ -207,7 +230,12 @@ install_local() {
   install_cloudflared
   log "[3/4] Provisioning tunnel..."
   provision_tunnel
-  install_systemd_services
+
+  if [[ "${USE_PM2:-}" == "true" ]]; then
+    install_pm2_services
+  else
+    install_systemd_services || install_pm2_services
+  fi
 }
 
 # ── Docker mode ────────────────────────────────────────────────────────────────
@@ -230,6 +258,11 @@ print_summary() {
     printf '  make status   - check service status\n'
     printf '  make restart  - restart services\n'
     printf '  make stop     - stop services\n'
+    if has pm2; then
+      printf '\nPM2 commands:\n'
+      printf '  pm2 list      - status of all processes\n'
+      printf '  pm2 logs      - view logs\n'
+    fi
   else
     printf 'Manage services:\n'
     printf '  make status   - check container status\n'


### PR DESCRIPTION
This PR adds PM2 support as an alternative to systemd for managing services in opencode-remote. It refactors the installation scripts to reduce duplication and updates the Makefile to support PM2 process management.

---
*PR created automatically by Jules for task [17066432528922630255](https://jules.google.com/task/17066432528922630255) started by @Ven0m0*