### PR TITLE
🧪 [testing] add unit tests for formatHashLines and computeHash

### DIFF
--- a/opencode/plugins/cachebro.ts
+++ b/opencode/plugins/cachebro.ts
@@ -91,7 +91,7 @@ const CachebroPlugin: Plugin = async ({ worktree, $ }) => {
       if (!filePath) return;
       try {
         await invalidatingCache.onFileChanged(filePath);
-      } catch (e) {
+      } catch (_e) {
         // Silently ignore file change errors
       }
     },
@@ -101,7 +101,7 @@ const CachebroPlugin: Plugin = async ({ worktree, $ }) => {
       if (!filePath) return;
       try {
         await invalidatingCache.onFileChanged(filePath);
-      } catch (e) {
+      } catch (_e) {
         // Silently ignore file change errors
       }
     },

--- a/opencode/plugins/context-shield.ts
+++ b/opencode/plugins/context-shield.ts
@@ -301,16 +301,16 @@ export const OpenCodeContextShieldPlugin: Plugin = async ({ directory }) => {
       const args = output.args as Record<string, unknown>;
 
       if (input.tool === 'read') {
-        const currentLimit = typeof args['limit'] === 'number' ? args['limit'] : undefined;
+        const currentLimit = typeof args.limit === 'number' ? args.limit : undefined;
         if (currentLimit === undefined || currentLimit > config.readLimit) {
-          args['limit'] = config.readLimit;
+          args.limit = config.readLimit;
         }
       }
 
       if (input.tool === 'task') {
-        const currentPrompt = typeof args['prompt'] === 'string' ? args['prompt'] : '';
+        const currentPrompt = typeof args.prompt === 'string' ? args.prompt : '';
         if (currentPrompt && !currentPrompt.includes(TASK_ROUTING_TAG)) {
-          args['prompt'] = `${currentPrompt}\n\n${TASK_ROUTING_BLOCK}`;
+          args.prompt = `${currentPrompt}\n\n${TASK_ROUTING_BLOCK}`;
         }
       }
     },
@@ -350,8 +350,8 @@ export const OpenCodeContextShieldPlugin: Plugin = async ({ directory }) => {
 
       if (isMcpResultShape(payload)) {
         const textParts = payload.content
-          .filter((item: Record<string, unknown>) => item['type'] === 'text' && typeof item['text'] === 'string')
-          .map((item: Record<string, unknown>) => item['text'] as string);
+          .filter((item: Record<string, unknown>) => item.type === 'text' && typeof item.text === 'string')
+          .map((item: Record<string, unknown>) => item.text as string);
 
         if (textParts.length === 0) return;
 
@@ -363,7 +363,7 @@ export const OpenCodeContextShieldPlugin: Plugin = async ({ directory }) => {
         });
 
         if (compacted.compacted) {
-          const nonText = payload.content.filter((item: Record<string, unknown>) => item['type'] !== 'text');
+          const nonText = payload.content.filter((item: Record<string, unknown>) => item.type !== 'text');
           payload.content = [{ type: 'text', text: compacted.output }, ...nonText];
         }
 

--- a/opencode/plugins/rtk-rewrite.ts
+++ b/opencode/plugins/rtk-rewrite.ts
@@ -110,12 +110,12 @@ export const OpenCodeRtkRewritePlugin: Plugin = async () => {
       if (input.tool !== 'bash') return;
 
       const args = output.args as Record<string, unknown>;
-      const command = typeof args['command'] === 'string' ? args['command'] : '';
+      const command = typeof args.command === 'string' ? args.command : '';
       if (!command) return;
 
       const rewritten = await tryRewrite(command);
       if (rewritten) {
-        args['command'] = rewritten;
+        args.command = rewritten;
       }
     },
   };

--- a/opencode/plugins/rtk.ts
+++ b/opencode/plugins/rtk.ts
@@ -22,7 +22,7 @@ function truncate(text: string, maxLines: number, keepHead = 20, keepTail = 20):
 }
 
 function stripAnsi(text: string): string {
-  return text.replace(new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g'), '');
+  return text.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
 }
 
 function collapseWhitespace(text: string): string {

--- a/opencode/tools/hashline_utils.test.ts
+++ b/opencode/tools/hashline_utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { computeHash, formatHashLines, DICT, NIBBLE } from './hashline_utils';
+
+describe('hashline_utils', () => {
+  describe('computeHash', () => {
+    test('should compute consistent hash for same content', () => {
+      const h1 = computeHash(1, 'hello world');
+      const h2 = computeHash(1, 'hello world');
+      expect(h1).toBe(h2);
+      expect(h1).toMatch(/^[ZPMQVRWSNKTXJBYH]{2}$/);
+    });
+
+    test('should ignore trailing whitespace', () => {
+      const h1 = computeHash(1, 'hello world');
+      const h2 = computeHash(1, 'hello world   ');
+      expect(h1).toBe(h2);
+    });
+
+    test('should ignore carriage returns', () => {
+      const h1 = computeHash(1, 'hello world\n');
+      const h2 = computeHash(1, 'hello world\r\n');
+      // computeHash trims end of text after replacing \r
+      // 'hello world\n'.replace(/\r/g, '').trimEnd() -> 'hello world'
+      // 'hello world\r\n'.replace(/\r/g, '').trimEnd() -> 'hello world'
+      expect(computeHash(1, 'hello world')).toBe(computeHash(1, 'hello world\r'));
+    });
+
+    test('should use line number as seed for whitespace-only lines', () => {
+      const h1 = computeHash(1, '   ');
+      const h2 = computeHash(2, '   ');
+      const h3 = computeHash(3, '   ');
+      // Bun.hash.xxHash32('', 1) % 256 and Bun.hash.xxHash32('', 2) % 256
+      // both happen to return 146, so we check more values.
+      expect([h1, h2, h3].filter((v, i, a) => a.indexOf(v) === i).length).toBeGreaterThan(1);
+    });
+
+    test('should NOT use line number as seed for significant content', () => {
+      const h1 = computeHash(1, 'content');
+      const h2 = computeHash(2, 'content');
+      expect(h1).toBe(h2);
+    });
+  });
+
+  describe('formatHashLines', () => {
+    test('should return empty string for empty input', () => {
+      expect(formatHashLines('')).toBe('');
+    });
+
+    test('should format single line correctly', () => {
+      const content = 'first line';
+      const hash = computeHash(1, content);
+      expect(formatHashLines(content)).toBe(`1#${hash}|${content}`);
+    });
+
+    test('should format multiple lines with correct line numbers', () => {
+      const content = 'line 1\nline 2\nline 3';
+      const lines = content.split('\n');
+      const expected = lines
+        .map((line, i) => `${i + 1}#${computeHash(i + 1, line)}|${line}`)
+        .join('\n');
+      expect(formatHashLines(content)).toBe(expected);
+    });
+
+    test('should respect startLine parameter', () => {
+      const content = 'line A\nline B';
+      const startLine = 10;
+      const lines = content.split('\n');
+      const expected = lines
+        .map((line, i) => `${startLine + i}#${computeHash(startLine + i, line)}|${line}`)
+        .join('\n');
+      expect(formatHashLines(content, startLine)).toBe(expected);
+    });
+
+    test('should handle trailing newline in content', () => {
+      const content = 'line 1\n';
+      // split('\n') on 'line 1\n' gives ['line 1', '']
+      const h1 = computeHash(1, 'line 1');
+      const h2 = computeHash(2, '');
+      expect(formatHashLines(content)).toBe(`1#${h1}|line 1\n2#${h2}|`);
+    });
+  });
+});

--- a/opencode/tools/hashline_utils.test.ts
+++ b/opencode/tools/hashline_utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { computeHash, formatHashLines, DICT, NIBBLE } from './hashline_utils';
+import { computeHash, formatHashLines } from './hashline_utils';
 
 describe('hashline_utils', () => {
   describe('computeHash', () => {
@@ -17,8 +17,8 @@ describe('hashline_utils', () => {
     });
 
     test('should ignore carriage returns', () => {
-      const h1 = computeHash(1, 'hello world\n');
-      const h2 = computeHash(1, 'hello world\r\n');
+      const _h1 = computeHash(1, 'hello world\n');
+      const _h2 = computeHash(1, 'hello world\r\n');
       // computeHash trims end of text after replacing \r
       // 'hello world\n'.replace(/\r/g, '').trimEnd() -> 'hello world'
       // 'hello world\r\n'.replace(/\r/g, '').trimEnd() -> 'hello world'
@@ -55,9 +55,7 @@ describe('hashline_utils', () => {
     test('should format multiple lines with correct line numbers', () => {
       const content = 'line 1\nline 2\nline 3';
       const lines = content.split('\n');
-      const expected = lines
-        .map((line, i) => `${i + 1}#${computeHash(i + 1, line)}|${line}`)
-        .join('\n');
+      const expected = lines.map((line, i) => `${i + 1}#${computeHash(i + 1, line)}|${line}`).join('\n');
       expect(formatHashLines(content)).toBe(expected);
     });
 

--- a/opencode/tools/json_repair.ts
+++ b/opencode/tools/json_repair.ts
@@ -181,7 +181,7 @@ if (results.length === 1) {
       for (const p of [scriptPath, inputPath]) {
         try {
           if (existsSync(p)) unlinkSync(p);
-        } catch (e) {
+        } catch (_e) {
           // Silently ignore cleanup errors
         }
       }


### PR DESCRIPTION
🎯 **What:** Missing tests for hashline_utils.ts. 
📊 **Coverage:** Added tests for computeHash (whitespace, carriage returns, seeds) and formatHashLines (empty input, single line, multi-line, startLine parameter, trailing newlines). 
✨ **Result:** Improved test coverage for hashline utilities.

---
*PR created automatically by Jules for task [3862752046750267331](https://jules.google.com/task/3862752046750267331) started by @Ven0m0*