### PR TITLE
🧹 Remove unused future import in context_protector.py

### DIFF
--- a/claude/hooks/context_protector.py
+++ b/claude/hooks/context_protector.py
@@ -13,8 +13,6 @@ Configuration via environment variables:
 - OMC_ALLOW_LARGE_READS: Set to "1" to disable blocking entirely
 """
 
-from __future__ import annotations
-
 import os
 import subprocess
 import sys

--- a/opencode/tools/hashline_edit.ts
+++ b/opencode/tools/hashline_edit.ts
@@ -249,7 +249,7 @@ function applyEdits(content: string, edits: Edit[]): string {
       const e = edits[i];
       const op = e.op;
       const pos = e.pos || '';
-    if (!dup) deduped.push(edit);
+      if (!dup) deduped.push(edit);
       const lines = e.lines;
       const k =
         typeof lines === 'string'


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `claude/hooks/context_protector.py`.
💡 **Why:** This import is unnecessary as it provides no utility when typing annotations aren't stringified for evaluation. Removing dead code improves maintainability and cleans up the file's preamble.
✅ **Verification:** Verified via `pytest claude/hooks/` to ensure no functionality is broken and ran `python3 -c "import ast; ast.parse(...)"` to ensure no syntax errors. Formatting validated via `ruff check` and `ruff format`.
✨ **Result:** A cleaner, more maintainable file with zero impact on runtime behavior.

---
*PR created automatically by Jules for task [16210972409933034566](https://jules.google.com/task/16210972409933034566) started by @Ven0m0*