### PR TITLE
🧹 [code health] remove unused future import in collect.py

### DIFF
--- a/claude/skills/todo-triage/scripts/collect.py
+++ b/claude/skills/todo-triage/scripts/collect.py
@@ -9,8 +9,6 @@ Usage:
     python3 collect.py . --include "*.py" "*.ts" --output /tmp/raw.json
 """
 
-from __future__ import annotations
-
 import argparse
 import fnmatch
 import json

--- a/opencode/tools/hashline_edit.ts
+++ b/opencode/tools/hashline_edit.ts
@@ -249,7 +249,7 @@ function applyEdits(content: string, edits: Edit[]): string {
       const e = edits[i];
       const op = e.op;
       const pos = e.pos || '';
-    if (!dup) deduped.push(edit);
+      if (!dup) deduped.push(edit);
       const lines = e.lines;
       const k =
         typeof lines === 'string'


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import statement in `claude/skills/todo-triage/scripts/collect.py`.
💡 **Why:** This import was unused and removing it simplifies the code, improving readability.
✅ **Verification:** Ran `uv run ruff check` and `uv run ruff format --check` to verify no linting or formatting issues were introduced. Ran the repository test suite (`pytest --ignore=claude/skills/toon-formatter`) to ensure no regressions.
✨ **Result:** Cleaned up the imports list by removing unused dead code without breaking any functionality.

---
*PR created automatically by Jules for task [4803071246439591760](https://jules.google.com/task/4803071246439591760) started by @Ven0m0*